### PR TITLE
Refer to dart.js bootstrap in packages

### DIFF
--- a/lesson-01/lesson-01.html
+++ b/lesson-01/lesson-01.html
@@ -7,6 +7,6 @@
     <canvas id="drawHere" width="400" height="400"></canvas>
     
     <script type="application/dart" src="Lesson-01.dart"></script>
-    <script src="../packages/browser/dart.js"></script>
+    <script src="packages/browser/dart.js"></script>
   </body>
 </html>

--- a/lesson-02/lesson-02.html
+++ b/lesson-02/lesson-02.html
@@ -7,6 +7,6 @@
     <canvas id="drawHere" width="400" height="400"></canvas>
     
     <script type="application/dart" src="Lesson-02.dart"></script>
-    <script src="../packages/browser/dart.js"></script>
+    <script src="packages/browser/dart.js"></script>
   </body>
 </html>

--- a/lesson-03/lesson-03.html
+++ b/lesson-03/lesson-03.html
@@ -7,6 +7,6 @@
     <canvas id="drawHere" width="400" height="400"></canvas>
     
     <script type="application/dart" src="Lesson-03.dart"></script>
-    <script src="../packages/browser/dart.js"></script>
+    <script src="packages/browser/dart.js"></script>
   </body>
 </html>

--- a/lesson-04/lesson-04.html
+++ b/lesson-04/lesson-04.html
@@ -7,6 +7,6 @@
     <canvas id="drawHere" width="400" height="400"></canvas>
     
     <script type="application/dart" src="Lesson-04.dart"></script>
-    <script src="../packages/browser/dart.js"></script>
+    <script src="packages/browser/dart.js"></script>
   </body>
 </html>

--- a/lesson-05/lesson-05.html
+++ b/lesson-05/lesson-05.html
@@ -7,6 +7,6 @@
     <canvas id="drawHere" width="400" height="400"></canvas>
     
     <script type="application/dart" src="Lesson-05.dart"></script>
-    <script src="../packages/browser/dart.js"></script>
+    <script src="packages/browser/dart.js"></script>
   </body>
 </html>

--- a/lesson-06/lesson-06.html
+++ b/lesson-06/lesson-06.html
@@ -8,6 +8,6 @@
     <canvas id="drawHere" width="400" height="400"></canvas>
     
     <script type="application/dart" src="Lesson-06.dart"></script>
-    <script src="http://dart.googlecode.com/svn/branches/bleeding_edge/dart/client/dart.js"></script>
+    <script src="packages/browser/dart.js"></script>
   </body>
 </html>

--- a/lesson-07/lesson-07.html
+++ b/lesson-07/lesson-07.html
@@ -14,6 +14,6 @@
     </p>
 
     <script type="application/dart" src="Lesson-07.dart"></script>
-    <script src="http://dart.googlecode.com/svn/branches/bleeding_edge/dart/client/dart.js"></script>
+    <script src="packages/browser/dart.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Lesson 6 and 7 used a deprecated file. Changes according to
http://news.dartlang.org/2013/01/big-breaking-change-dartjs-bootstrap-file-moving-to-pub.html
